### PR TITLE
Hiding references and notability warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,11 @@ function printWikiSummary(queryText) {
 
         if (inSummary && !inTable
                       && !line.startsWith('<td', '<table', '<a')
-                      && !line.includes('needs additional citations')) {
+                      && !line.includes('needs additional citations')
+                      && !line.includes('box-Notability')
+                      && !line.includes('mw-cite-backlink')
+                      && !line.includes('id="References"')
+                      && !line.includes('Wikipedia:Stub')) {
           summaryLines.push(line);
         }
       }


### PR DESCRIPTION
Small change to hide references and notability warnings (see output of "wikit Crown Trust" as an example). 

Possible fix for issue #15, although some more examples will need to be found and tested. Before and after output shown below...

```
robert@uat-debian-web:~/wikit/wikit$ wikit Crown Trust
 The topic of this article may not meet Wikipedia's notability guidelines for companies
 and organizations. Please help to establish notability by citing reliable secondary
 sources that are independent of the topic and provide significant coverage of it
 beyond a mere trivial mention. If notability cannot be established, the article
 is likely to be merged, redirected, or deleted. Find sources: "Crown Trust" – news ·
 newspapers · books · scholar · JSTOR (February 2017) (Learn how and when to remove
 this template message)   The Crown Trust Company was an Ontario-based firm that
 operated in most of Canada prior to its bankruptcy (along with several other trusts
 in 1983), due to the inflation of the currency.  History   In January 1946, Crown
 Trust merged with Guarantee Trust of Montreal.   It eventually came to be controlled
 by Argus Corporation.  References    1. ^ montreal.qc.ca: "Saint-Jacques, la rue
 des banques: FICHE D'UN BÂTIMENT - 393, rue Saint-Jacques"  2. ^ nslegislature.ca:
 "Central Trust Company Act - CHAPTER 64 OF THE REVISED STATUTES, 1989"  3. ^ news.google.com:
 "The Montreal Gazette - Feb 7, 1946"  This bank, insurance, or other financial services
 corporation article is a stub. You can help Wikipedia by expanding it.  - v - t
 - e
robert@uat-debian-web:~/wikit/wikit$ nodejs index.js Crown Trust
 The Crown Trust Company was an Ontario-based firm that operated in most of Canada
 prior to its bankruptcy (along with several other trusts in 1983), due to the inflation
 of the currency.  History   In January 1946, Crown Trust merged with Guarantee Trust
 of Montreal.   It eventually came to be controlled by Argus Corporation.
```