### PR TITLE
Changed process.title on startup

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
+process.title = 'wikit';
 const path = require('path');
 const fs = require('fs');
 


### PR DESCRIPTION
This pull request sets the `process.title` variable on startup. When `wikit` starts up, the process will be named `wikit`.